### PR TITLE
Add smoke tests for MCP endpoints (issue #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,33 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 [![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/HarshK15/skills-integrate-mcp-with-copilot/issues/1)
 
----
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+
+## Running the example MCP endpoints
+
+This repository includes a minimal MCP-like provider implemented as two HTTP
+endpoints in `src/app.py`:
+
+- `GET /mcp/context` — returns a small set of project files (for use as model
+	context)
+- `GET /mcp/summary` — returns a compact project summary
+
+To run the app locally:
+
+```bash
+pip install -r requirements.txt
+uvicorn src.app:app --reload --host 0.0.0.0 --port 8000
+```
+
+Then try the MCP endpoints:
+
+```bash
+curl -s http://localhost:8000/mcp/summary | jq
+curl -s http://localhost:8000/mcp/context | jq '.files | keys'
+```
+
+This is a small, safe example meant for learning; a production MCP provider
+should include authentication, careful filtering of file contents, rate
+limiting, and other protections.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+pytest

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,32 @@
+from fastapi.testclient import TestClient
+from src.app import app
+
+
+client = TestClient(app)
+
+
+def test_mcp_summary():
+    resp = client.get("/mcp/summary")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    assert "title" in data
+    assert "endpoints" in data
+
+
+def test_mcp_context():
+    resp = client.get("/mcp/context")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    # files key should exist (may be empty depending on environment)
+    assert "files" in data
+
+
+def test_activities_get():
+    resp = client.get("/activities")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    # the example dataset includes Chess Club
+    assert "Chess Club" in data


### PR DESCRIPTION
This PR adds a small pytest-based smoke test suite that validates the `/mcp/summary`, `/mcp/context`, and `/activities` endpoints.

- Adds `tests/test_smoke.py` using FastAPI TestClient.
- Adds `pytest` to `requirements.txt` so tests can be run locally or in CI.

These tests are intended as a quick smoke check for issue #8. They are intentionally minimal and can be expanded in follow-up work (see issue #11 for CI/tests).

To run locally:

```bash
pip install -r requirements.txt
pytest -q
```
